### PR TITLE
Updating gitmodules to use https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "json-relay"]
 	path = json-relay
-	url = git@github.com:hammerlab/json-relay-spark-listener.git
+	url = https://github.com/hammerlab/json-relay-spark-listener.git
 [submodule "slim"]
 	path = slim
-	url = git@github.com:hammerlab/slim.git
+	url = https://github.com/hammerlab/slim.git


### PR DESCRIPTION
HTTPS is the recommended way, it allows folks with push access to be able to push stuff, while those with just pull access (and no ssh keys) to be able to read stuff. If someone with git improperly set up or no ssh keys tries to do a recursive clone on the top level repo, cloning of submodules will fail because it is harded to use https.

If you are curious about different between various git cloning protocols, this may be interesting:
https://help.github.com/articles/which-remote-url-should-i-use/