### PR TITLE
Fix minor formatting issues

### DIFF
--- a/ui/client/lib/lib/display/renderers.jsx
+++ b/ui/client/lib/lib/display/renderers.jsx
@@ -80,7 +80,7 @@ formatBytes = function(bytes) {
 };
 
 formatNumber = function(n) {
-  if (!n) return "-";
+  if (!n && n !== 0) return "-";
   if (typeof n != 'number') return n;
   var cutoff = 2;
   var levels = [['', 1], ['MM', 1000000], ['B', 1000], ['T', 1000]];
@@ -96,6 +96,7 @@ formatNumber = function(n) {
 };
 
 formatPercent = (p) => {
+  if (!p) return "-";
   return (100*p).toString().substr(0, 3) + '%';
 };
 
@@ -131,5 +132,4 @@ getHostPort = function(e) {
   return null;
 };
 
-defaultRenderer = (x) => { if (!x) return '-'; return x; };
-
+defaultRenderer = (x) => { if (!x && x !== 0) return '-'; return x; };


### PR DESCRIPTION
This PR fixes issues with displaying `0` in Spark UI.
- default renderer affects task and executor ids, previously was `-`
- numeric renderer for values that are 0s, previously was `-`
- percent formatting for % memory used when `MemPercent` is not filled in Mongo, previously was `NaN%`
