### PR TITLE
Update sort triangle

### DIFF
--- a/ui/client/widgets/table/header.jsx
+++ b/ui/client/widgets/table/header.jsx
@@ -29,20 +29,12 @@ TableHeader = React.createClass({
     var opts = Cookie.get(this.props.tableOptsKey) || {};
     var sort = opts.sort;
     var isCurrentSort = this.isCurrentSort();
+    // sort triangle (1-UP/2-DOWN) with space when sort is enabled, otherwise non-rendered null
+    var currentSortSpan = (isCurrentSort == 1) ? <span>&nbsp;&#x25B2;</span> :
+      ((isCurrentSort == -1) ? <span>&nbsp;&#x25BC;</span> : null);
     return <th onClick={this.onClick}>
-      {
-        this.props.label +
-        (
-              (isCurrentSort == 1) ?
-                    ' ▴' :
-                    ((isCurrentSort == -1) ?
-                          ' ▾' :
-                          ''
-                    )
-        )
-      }
+      <span>{this.props.label}</span>
+      {currentSortSpan}
     </th>
   }
 });
-
-

--- a/ui/client/widgets/table/header.jsx
+++ b/ui/client/widgets/table/header.jsx
@@ -29,7 +29,7 @@ TableHeader = React.createClass({
     var opts = Cookie.get(this.props.tableOptsKey) || {};
     var sort = opts.sort;
     var isCurrentSort = this.isCurrentSort();
-    // sort triangle (1-UP/2-DOWN) with space when sort is enabled, otherwise non-rendered null
+    // sort triangle (1 UP/-1 DOWN) with space when sort is enabled, otherwise non-rendered null
     var currentSortSpan = (isCurrentSort == 1) ? <span>&nbsp;&#x25B2;</span> :
       ((isCurrentSort == -1) ? <span>&nbsp;&#x25BC;</span> : null);
     return <th onClick={this.onClick}>


### PR DESCRIPTION
This PR updates sorting triangle for each column. Before this fix unicode symbols are displayed with different height (and sort of size) - same in Spark UI, so I replaced them with `&#x25B2;` and `&#x25BC;`, which are a little bit fat, but at least consistent in size.

Currently:
![old-triangle-down](https://cloud.githubusercontent.com/assets/7788766/17648823/b168d8be-6277-11e6-8c2a-01b028a7ecde.png)
![old-triangle-up](https://cloud.githubusercontent.com/assets/7788766/17648824/b16a8254-6277-11e6-9ae8-d045604d7766.png)

After:
![new-triangle-down](https://cloud.githubusercontent.com/assets/7788766/17648828/c6b0f422-6277-11e6-97f8-1a3af72d0221.png)
![new-triangle-up](https://cloud.githubusercontent.com/assets/7788766/17648829/c6e5dcfa-6277-11e6-92c0-93140f4ef205.png)

Again, this is very minor and subjective, so all ideas/suggestions are super welcome. Happy to close, if someone finds these triangles inappropriate.
