### PR TITLE
Separate applications on running and completed

### DIFF
--- a/ui/client/lib/lib/collections.js
+++ b/ui/client/lib/lib/collections.js
@@ -8,7 +8,9 @@ NumStageExecutors = new Mongo.Collection("num-stage-executors");
 NumRDDs = new Mongo.Collection("num-rdds");
 NumRDDExecutors = new Mongo.Collection("num-rdd-executors");
 NumRDDBlocks = new Mongo.Collection("num-rdd-blocks");
-NumApplications = new Mongo.Collection("num-applications");
+
+NumRunningApplications = new Mongo.Collection("num-running-applications");
+NumCompletedApplications = new Mongo.Collection("num-completed-applications");
 
 StageCounts = new Mongo.Collection("stage-counts");
 AllStages = new Mongo.Collection("all-stages");

--- a/ui/client/pages/apps/apps.html
+++ b/ui/client/pages/apps/apps.html
@@ -7,11 +7,25 @@
     <div>
       {{>React
           component=Table
-          name="apps"
-          title="Spark Applications"
+          name="running-apps"
+          title="Running Applications"
           collection="Applications"
           columns=columns
-          totalCollection="NumApplications"
+          selector=runningAppsSelector
+          totalCollection="NumRunningApplications"
+          sortId='id'
+          sortDir=-1
+      }}
+    </div>
+    <div>
+      {{>React
+          component=Table
+          name="completed-apps"
+          title="Completed Applications"
+          collection="Applications"
+          columns=columns
+          selector=completedAppsSelector
+          totalCollection="NumCompletedApplications"
           sortId='id'
           sortDir=-1
       }}

--- a/ui/client/pages/apps/apps.jsx
+++ b/ui/client/pages/apps/apps.jsx
@@ -11,10 +11,11 @@ Router.route("/", {
     }
     return [
       Meteor.subscribe("apps", opts),
-      Meteor.subscribe("num-applications")
+      Meteor.subscribe("num-running-applications"),
+      Meteor.subscribe("num-completed-applications"),
     ];
   },
-  action:function() {
+  action: function() {
     this.render('appsPage', { data: { apps: Applications.find() } });
   }
 });
@@ -33,5 +34,7 @@ var columns = [
 ];
 
 Template.appsPage.helpers({
-  columns: () => { return columns; }
+  columns: () => { return columns; },
+  runningAppsSelector: () => { return isAppRunningQuery(); },
+  completedAppsSelector: () => { return isAppCompletedQuery(); }
 });

--- a/ui/lib/status.js
+++ b/ui/lib/status.js
@@ -24,4 +24,14 @@ lstatuses = {
   5: "removed"
 };
 
+// function to determine whether or not application is running or pending
+// status <= 1 or undefined
+isAppRunningQuery = function() {
+  return {$or: [{status: {$lte: 1}}, {status: undefined}]};
+}
 
+// function to return completed application status (completed, removed, skipped, failed)
+// status > 1
+isAppCompletedQuery = function() {
+  return {status: {$gt: 1}};
+}


### PR DESCRIPTION
This PR adds minor update to applications page and splits current table into 2:
- Running Applications (running + pending, or `status <= 1 or status = undefined`
- Completed Applications (`status > 1`)

This change is relatively minor and optional, though I think it can be quite handy.

Here is what it looks like (dummy data):
![screen shot 2016-08-23 at 9 55 29 pm](https://cloud.githubusercontent.com/assets/7788766/17887962/df77874e-697c-11e6-924e-27c5e81b5db9.png)

Code is **super-hacky**, so I would appreciate any suggestions and help + not sure about performance impact for listing applications.
