### PR TITLE
Executor thread dump (spree part)

### DIFF
--- a/ui/client/css/main.less
+++ b/ui/client/css/main.less
@@ -259,6 +259,12 @@ ul.unstyled {
   margin: 16px 10px;
 }
 
+.accordion-global-time {
+  display: block;
+  margin: 16px 10px;
+  color: #777;
+}
+
 .accordion-group {
   margin-bottom: 4px;
   border: 1px solid #e5e5e5;

--- a/ui/client/css/main.less
+++ b/ui/client/css/main.less
@@ -253,3 +253,29 @@ ul.unstyled {
     width: 50%;
   }
 }
+
+.accordion-global-toggle {
+  display: block;
+  margin: 16px 10px;
+}
+
+.accordion-group {
+  margin-bottom: 4px;
+  border: 1px solid #e5e5e5;
+  border-radius: 4px;
+  background: #fafafa;
+
+  .accordion-header {
+    .accordion-toggle {
+      display: block;
+      padding: 8px 15px;
+    }
+  }
+
+  .accordion-body {
+    margin: 8px;
+    pre {
+      font-size: 12px;
+    }
+  }
+}

--- a/ui/client/pages/executors/executors.jsx
+++ b/ui/client/pages/executors/executors.jsx
@@ -20,6 +20,20 @@ Router.route("/a/:_appId/executors", {
   name: 'executors'
 });
 
+// thread dump column for executor
+var threadDumpColumn = new Column(
+  'threadDump',
+  'Thread Dump',
+  'id',
+  {
+    render: (executor) => {
+      var href = ["", "a", executor.appId, "executors", executor.id, "threadDump"].join('/');
+      return <div><a href={href}>Thread Dump</a></div>;
+    },
+    renderKey: ''
+  }
+);
+
 var baseExecutorColumns = [
   new Column('id', 'ID', 'id', { truthyZero: 0 }),
   hostColumn,
@@ -39,7 +53,8 @@ var baseExecutorColumns = [
       .concat(taskColumns)
       .concat(taskTimeRollupColumns)
       .concat(ioColumns())
-      .concat([logUrlsColumn]);
+      .concat([logUrlsColumn])
+      .concat([threadDumpColumn]);
 
 var executorEndedColumns = [
   reasonColumn,

--- a/ui/client/pages/executors/executors.jsx
+++ b/ui/client/pages/executors/executors.jsx
@@ -27,7 +27,7 @@ var threadDumpColumn = new Column(
   'id',
   {
     render: (executor) => {
-      var href = ["", "a", executor.appId, "executors", executor.id, "threadDump"].join('/');
+      var href = ['', 'a', executor.appId, 'executors', executor.id, 'threadDump'].join('/');
       return <div><a href={href}>Thread Dump</a></div>;
     },
     renderKey: ''

--- a/ui/client/pages/threaddump/threaddump.html
+++ b/ui/client/pages/threaddump/threaddump.html
@@ -1,0 +1,12 @@
+
+<template name="threadDumpPage">
+  {{>navbar}}
+  {{setTitle this}}
+  {{log this}}
+  <div class="container">
+    <h3>Thread dump for executor {{execId}}</h3>
+    <div>
+      {{>React getThreadDumpList threads}}
+    </div>
+  </div>
+</template>

--- a/ui/client/pages/threaddump/threaddump.jsx
+++ b/ui/client/pages/threaddump/threaddump.jsx
@@ -61,6 +61,7 @@ ThreadDumpList = React.createClass({
     this.setState({isGloballyCollapsed: !this.state.isGloballyCollapsed})
   },
   getLastUpdateTime() {
+    // last update time is select as maximum update time for all executor threads
     var time = "Undefined";
     if (this.props.threads) {
       var updates = this.props.threads.map(function(thread) {

--- a/ui/client/pages/threaddump/threaddump.jsx
+++ b/ui/client/pages/threaddump/threaddump.jsx
@@ -35,7 +35,7 @@ ThreadTraceBox = React.createClass({
     this.setState({isCollapsed: !this.state.isCollapsed});
   },
   render() {
-    var header = "Thread " + this.props.thread.threadId + ": " + this.props.thread.threadName +
+    var header = "Thread " + this.props.thread.id + ": " + this.props.thread.threadName +
       " (" + this.props.thread.threadState + ")";
     return <div className="accordion-group">
       <div className="accordion-header">
@@ -48,6 +48,9 @@ ThreadTraceBox = React.createClass({
   }
 })
 
+// Showing global list of threads for executor. Also displays link to toggle all thread dump stack
+// traces using `isGloballyCollapsed`, this will either collapse or expand stack traces regardless
+// of their state, which will be reset to global.
 ThreadDumpList = React.createClass({
   getInitialState() {
     return {
@@ -57,20 +60,36 @@ ThreadDumpList = React.createClass({
   toggleGlobal() {
     this.setState({isGloballyCollapsed: !this.state.isGloballyCollapsed})
   },
+  getLastUpdateTime() {
+    var time = "Undefined";
+    if (this.props.threads) {
+      var updates = this.props.threads.map(function(thread) {
+        return thread.l;
+      });
+      time = formatDateTime(Math.max(...updates));
+    }
+    return time;
+  },
   render() {
     var globallyCollapsed = this.state.isGloballyCollapsed;
     var components = this.props.threads.map(function(thread) {
-      return <ThreadTraceBox key={thread.threadId} thread={thread}
+      return <ThreadTraceBox key={thread.id} thread={thread}
         isGloballyCollapsed={globallyCollapsed} />;
     });
 
-    return <div>
-      <div className="accordion-global-toggle">
-        <a href="#" onClick={this.toggleGlobal}>
-          {(globallyCollapsed) ? "Expand All" : "Collapse All"}</a>
-      </div>
-      {components}
-    </div>;
+    // Only display data if there is at least one thread in array
+    if (this.props.threads instanceof Array && this.props.threads.length) {
+      return <div>
+        <div className="accordion-global-time">Last update time: {this.getLastUpdateTime()}</div>
+        <div className="accordion-global-toggle">
+          <a href="#" onClick={this.toggleGlobal}>
+            {(globallyCollapsed) ? "Expand All" : "Collapse All"}</a>
+        </div>
+        {components}
+      </div>;
+    } else {
+      return <div>No data available</div>;
+    }
   }
 });
 

--- a/ui/client/pages/threaddump/threaddump.jsx
+++ b/ui/client/pages/threaddump/threaddump.jsx
@@ -1,0 +1,86 @@
+
+// Executors Page
+Router.route("/a/:_appId/executors/:_execId/threadDump", {
+  waitOn: function() {
+    return [
+      Meteor.subscribe('app', this.params._appId),
+      Meteor.subscribe('executor-thread-dumps', this.params._appId, this.params._execId)
+    ];
+  },
+  action: function() {
+    this.render("threadDumpPage", {
+      data: {
+        appId: this.params._appId,
+        app: Applications.findOne(),
+        execId: this.params._execId,
+        threads: ExecutorThreadDumps.find().fetch(),
+        executorsTab: 1
+      }
+    });
+  },
+  name: 'threads'
+});
+
+// Thread display box, takes 'thread' and 'isGloballyCollapsed' as props
+ThreadTraceBox = React.createClass({
+  getInitialState() {
+    return {
+      isCollapsed: this.props.isGloballyCollapsed
+    };
+  },
+  componentWillReceiveProps(nextProps) {
+    this.setState({isCollapsed: nextProps.isGloballyCollapsed});
+  },
+  toggleBody() {
+    this.setState({isCollapsed: !this.state.isCollapsed});
+  },
+  render() {
+    var header = "Thread " + this.props.thread.threadId + ": " + this.props.thread.threadName +
+      " (" + this.props.thread.threadState + ")";
+    return <div className="accordion-group">
+      <div className="accordion-header">
+        <a href="#" onClick={this.toggleBody} className="accordion-toggle">{header}</a>
+      </div>
+      <div className={"accordion-body" + ((this.state.isCollapsed) ? " hidden" : "")}>
+        <pre>{this.props.thread.stackTrace}</pre>
+      </div>
+    </div>;
+  }
+})
+
+ThreadDumpList = React.createClass({
+  getInitialState() {
+    return {
+      isGloballyCollapsed: true
+    };
+  },
+  toggleGlobal() {
+    this.setState({isGloballyCollapsed: !this.state.isGloballyCollapsed})
+  },
+  render() {
+    var globallyCollapsed = this.state.isGloballyCollapsed;
+    var components = this.props.threads.map(function(thread) {
+      return <ThreadTraceBox key={thread.threadId} thread={thread}
+        isGloballyCollapsed={globallyCollapsed} />;
+    });
+
+    return <div>
+      <div className="accordion-global-toggle">
+        <a href="#" onClick={this.toggleGlobal}>
+          {(globallyCollapsed) ? "Expand All" : "Collapse All"}</a>
+      </div>
+      {components}
+    </div>;
+  }
+});
+
+Template.threadDumpPage.helpers({
+  setTitle: function(data) {
+    if (data && data.appId && data.execId) {
+      document.title = "Thread dump for executor " + data.execId;
+    }
+  },
+  getThreadDumpList: function(threads) {
+    return {component: ThreadDumpList, threads: threads};
+  }
+});

--- a/ui/server/main.js
+++ b/ui/server/main.js
@@ -15,7 +15,7 @@ Meteor.startup(function() {
     [ StageAttempts, { appId: 1, stageId: 1, id: 1 } ],
     [ RDDs, { appId: 1, id: 1 } ],
     [ Executors, { appId: 1, id: 1 } ],
-    [ ExecutorThreadDumps, { appId: 1, execId: 1, threadId: 1 } ],
+    [ ExecutorThreadDumps, { appId: 1, execId: 1 } ],
     [ Tasks, { appId: 1, stageId: 1, id: 1 } ],
     [ TaskAttempts, { appId: 1, stageId: 1, stageAttemptId: 1, id: 1 } ],
     [ Environment, { appId: 1 } ]

--- a/ui/server/main.js
+++ b/ui/server/main.js
@@ -327,7 +327,9 @@ Meteor.publish("executors", function(appId, opts) {
 });
 
 Meteor.publish("executor-thread-dumps", function(appId, execId) {
-  return ExecutorThreadDumps.find({ appId: appId, execId: execId });
+  // we need to account for fact that executor id is integer in Mongo, but driver id is a string
+  var resolvedExecId = isNaN(parseInt(execId)) ? execId : parseInt(execId);
+  return ExecutorThreadDumps.find({ appId: appId, execId: resolvedExecId });
 });
 
 Meteor.publish("rdds", function(appId, opts) {

--- a/ui/server/main.js
+++ b/ui/server/main.js
@@ -15,6 +15,7 @@ Meteor.startup(function() {
     [ StageAttempts, { appId: 1, stageId: 1, id: 1 } ],
     [ RDDs, { appId: 1, id: 1 } ],
     [ Executors, { appId: 1, id: 1 } ],
+    [ ExecutorThreadDumps, { appId: 1, execId: 1, threadId: 1 } ],
     [ Tasks, { appId: 1, stageId: 1, id: 1 } ],
     [ TaskAttempts, { appId: 1, stageId: 1, stageAttemptId: 1, id: 1 } ],
     [ Environment, { appId: 1 } ]
@@ -323,6 +324,10 @@ Meteor.publish("environment-page", function(appId) {
 
 Meteor.publish("executors", function(appId, opts) {
   return Executors.find({ appId: appId }, opts);
+});
+
+Meteor.publish("executor-thread-dumps", function(appId, execId) {
+  return ExecutorThreadDumps.find({ appId: appId, execId: execId });
 });
 
 Meteor.publish("rdds", function(appId, opts) {

--- a/ui/spree.js
+++ b/ui/spree.js
@@ -9,6 +9,7 @@ StageExecutors = new Mongo.Collection("stage_executors");
 Tasks = new Mongo.Collection("tasks");
 //TaskAttempts = new Mongo.Collection("task_attempts");
 Executors = new Mongo.Collection("executors");
+ExecutorThreadDumps = new Mongo.Collection("executor_thread_dumps");
 RDDs = new Mongo.Collection("rdds");
 RDDExecutors = new Mongo.Collection("rdd_executors");
 Environment = new Mongo.Collection("environment");


### PR DESCRIPTION
This PR adds Executor thread dump page similar to Spark UI. Screenshots are below:
![screen shot 2016-08-26 at 7 40 08 am](https://cloud.githubusercontent.com/assets/7788766/17986689/0b66e2ce-6b70-11e6-9e03-f6093b2797b1.png)

![screen shot 2016-08-26 at 7 40 30 am](https://cloud.githubusercontent.com/assets/7788766/17986716/2c9bf150-6b70-11e6-9117-202ee6fbf83a.png)

![screen shot 2016-08-26 at 7 41 04 am](https://cloud.githubusercontent.com/assets/7788766/17986705/222abdd2-6b70-11e6-98b7-bd8252eed442.png)

This should be merged with corresponding changes in `spark-json-relay` and `slim`.
